### PR TITLE
Fix no_validate

### DIFF
--- a/check_apache_status.pl
+++ b/check_apache_status.pl
@@ -141,6 +141,7 @@ my $ua = LWP::UserAgent->new( protocols_allowed => ['http','https'], timeout => 
 
 if (defined($options->no_validate)) {
   $ua->ssl_opts ( verify_hostname => 0 );
+  $ua->ssl_opts ( SSL_verify_mode => 0 );
 }
 
 if (defined($options->ssl)) {


### PR DESCRIPTION
Related: https://github.com/libwww-perl/libwww-perl/issues/241

I can verify this fixed it for me. Without this patch, I still get certificate failures when checking on localhost over SSL even with no_validate set.