### PR TITLE
fix for SSLv3 errors, from https://stackoverflow.com/a/51128762

### DIFF
--- a/check_apache_status.pl
+++ b/check_apache_status.pl
@@ -6,7 +6,7 @@ use Monitoring::Plugin::Threshold;
 use LWP::UserAgent;
 use HTTP::Status qw(:constants :is status_message);
 
-our $VERSION = '1.4.0';
+our $VERSION = '1.4.2';
 
 our ( $plugin, $option );
 
@@ -138,6 +138,7 @@ if ( ($options->username ne '') && ($options->password ne '') ) {
 }
 
 my $ua = LWP::UserAgent->new( protocols_allowed => ['http','https'], timeout => 15);
+$ua->ssl_opts ( SSL_cipher_list => '' );
 
 if (defined($options->no_validate)) {
   $ua->ssl_opts ( verify_hostname => 0 );


### PR DESCRIPTION
We disable many older, insecure ciphers on our web servers, which prevents this check from working over https because it is defaulting to SSLv3.  From Stack Overflow answer https://stackoverflow.com/a/51128762, setting the LWP::UserAgent cipherlist to empty causes it to offer a much larger set of ciphers, which includes newer ones that our web servers accept.